### PR TITLE
Updates in ZContext, ZSocket and namespace ZeroMQ.Devices

### DIFF
--- a/Devices/PubSubDevice.cs
+++ b/Devices/PubSubDevice.cs
@@ -1,4 +1,4 @@
-﻿namespace ZeroMQ
+﻿namespace ZeroMQ.Devices
 {
 	using System;
 

--- a/Devices/PushPullDevice.cs
+++ b/Devices/PushPullDevice.cs
@@ -1,4 +1,4 @@
-﻿namespace ZeroMQ
+﻿namespace ZeroMQ.Devices
 {
 	using System;
 

--- a/Devices/RouterDealerDevice.cs
+++ b/Devices/RouterDealerDevice.cs
@@ -1,4 +1,4 @@
-﻿namespace ZeroMQ
+﻿namespace ZeroMQ.Devices
 {
 	/// <summary>
 	/// A Device on Routers and Dealers

--- a/Devices/StreamDealerDevice.cs
+++ b/Devices/StreamDealerDevice.cs
@@ -1,4 +1,4 @@
-﻿namespace ZeroMQ
+﻿namespace ZeroMQ.Devices
 {
 	using lib;
 	// using lib.sys;

--- a/ZActor.cs
+++ b/ZActor.cs
@@ -1,11 +1,6 @@
 ﻿namespace ZeroMQ
 {
-	using System;
-	using System.Collections.Generic;
-	using System.Security.Cryptography;
-	using System.Threading;
-
-	public delegate void ZAction(ZContext context, ZSocket backend, CancellationTokenSource cancellor, object[] args);
+	public delegate void ZAction(ZContext context, ZSocket backend, System.Threading.CancellationTokenSource cancellor, object[] args);
 
 	public class ZActor : ZThread
 	{
@@ -25,7 +20,7 @@
 			: this (context, default(string), action, args)
 		{
 			var rnd0 = new byte[8];
-			using (var rng = new RNGCryptoServiceProvider()) rng.GetBytes(rnd0);
+			using (var rng = new System.Security.Cryptography.RNGCryptoServiceProvider()) rng.GetBytes(rnd0);
 			this.Endpoint = string.Format("inproc://{0}", ZContext.Encoding.GetString(rnd0));
 		}
 

--- a/ZContext.cs
+++ b/ZContext.cs
@@ -247,6 +247,8 @@ namespace ZeroMQ
 
 				return false;
 			}
+
+			_contextPtr = IntPtr.Zero;
 			return true;
 		}
 

--- a/ZSocket.cs
+++ b/ZSocket.cs
@@ -305,7 +305,7 @@ namespace ZeroMQ
 		public void ReceiveBytes(byte[] buffer, int offset, int count)
 		{
 			ZError error;
-			if (-1 > ReceiveBytes(buffer, offset, count, ZSocketFlags.None, out error))
+			if (-1 == ReceiveBytes(buffer, offset, count, ZSocketFlags.None, out error))
 			{
 				throw new ZException(error);
 			}

--- a/ZSocket.cs
+++ b/ZSocket.cs
@@ -19,6 +19,7 @@ namespace ZeroMQ
 		/// <returns><see cref="ZSocket"/></returns>
 		public static ZSocket Create(ZContext context, ZSocketType socketType)
 		{
+
 			return new ZSocket(context, socketType);
 		}
 
@@ -305,7 +306,7 @@ namespace ZeroMQ
 		public void ReceiveBytes(byte[] buffer, int offset, int count)
 		{
 			ZError error;
-			if (-1 == ReceiveBytes(buffer, offset, count, ZSocketFlags.None, out error))
+			if (0 > ReceiveBytes(buffer, offset, count, ZSocketFlags.None, out error))
 			{
 				throw new ZException(error);
 			}

--- a/ZeroMQ.VS.csproj
+++ b/ZeroMQ.VS.csproj
@@ -54,10 +54,10 @@
     <Compile Include="ZFrameOption.cs" />
     <Compile Include="ZThread.cs" />
     <Compile Include="ZSocketSetup.cs" />
-    <Compile Include="PubSubDevice.cs" />
-    <Compile Include="PushPullDevice.cs" />
-    <Compile Include="RouterDealerDevice.cs" />
-    <Compile Include="StreamDealerDevice.cs" />
+    <Compile Include="Devices\PubSubDevice.cs" />
+    <Compile Include="Devices\PushPullDevice.cs" />
+    <Compile Include="Devices\RouterDealerDevice.cs" />
+    <Compile Include="Devices\StreamDealerDevice.cs" />
     <Compile Include="lib\DispoIntPtr.cs" />
     <Compile Include="lib\DispoIntPtr.Ansi.cs" />
     <Compile Include="lib\Platform.cs" />
@@ -128,4 +128,5 @@
     <None Include="README.md" />
     <None Include="ZeroMQ.snk" />
   </ItemGroup>
+  <ItemGroup />
 </Project>


### PR DESCRIPTION
ZContext now doesn't Terminate, if there was a Shutdown()

ZSocket now does return `bool SendBytes(...)` and `int ReceiveBytes(...)`.
The [Espresso_Publisher](https://github.com/metadings/zguide/blob/master/examples/C%23/espresso.cs#L45) returns `bool SendBytes(byte[5] bytes, 0, 5, ...)`,
and the [Espresso_Subscriber](https://github.com/metadings/zguide/blob/master/examples/C%23/espresso.cs#L75) returns `int bytesLength = ReceiveBytes(byte[10] bytes, 0, 10, ...)`

Moving RouterDealerDevice, StreamDealerDevice, PubSubDevice, PushPullDevice
back to namespace ZeroMQ.Devices.
