### PR TITLE
Support for Xamarin C# on iPhones

### DIFF
--- a/ZeroMQ.VS.csproj
+++ b/ZeroMQ.VS.csproj
@@ -41,6 +41,15 @@
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>ZeroMQ.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release iOS|AnyCPU'">
+    <OutputPath>bin\Release iOS\</OutputPath>
+    <DefineConstants>TRACE;IOS_INTERNAL</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/ZeroMQ.mono.csproj
+++ b/ZeroMQ.mono.csproj
@@ -39,6 +39,14 @@
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>ZeroMQ.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release iOS|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release iOS\</OutputPath>
+    <DefineConstants>TRACE;IOS_INTERNAL</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/lib/Platform.Win32.cs
+++ b/lib/Platform.Win32.cs
@@ -1,6 +1,7 @@
 ﻿namespace ZeroMQ.lib
 {
 	using System;
+	using System.ComponentModel;
 	using System.Diagnostics;
 	using System.IO;
 	using System.Reflection;
@@ -119,7 +120,7 @@
 
 			public static Exception GetLastLibraryError()
 			{
-				return Marshal.GetExceptionForHR(Marshal.GetHRForLastWin32Error());
+				return new Win32Exception();
 			}
 
 			[DllImport(KernelLib, CharSet = CharSet.Auto, BestFitMapping = false, SetLastError = true)]

--- a/lib/Platform.cs
+++ b/lib/Platform.cs
@@ -1,9 +1,8 @@
-using System.Linq;
-
 namespace ZeroMQ.lib
 {
 	using System;
 	using System.IO;
+	using System.Linq;
 	using System.Reflection;
 	using System.Runtime.InteropServices;
 

--- a/lib/Platform.cs
+++ b/lib/Platform.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 namespace ZeroMQ.lib
 {
 	using System;
@@ -236,6 +238,17 @@ namespace ZeroMQ.lib
 			}
 
 			Stream resourceStream = Assembly.GetExecutingAssembly().GetManifestResourceStream(resourceName);
+
+			if (resourceStream == null)
+			{
+				// Locate the resource in any of the current loaded assemblies
+				var resourceAssembly = AppDomain.CurrentDomain
+					.GetAssemblies()
+					.FirstOrDefault(ass => ass.GetManifestResourceNames().Contains(resourceName));
+
+				if (resourceAssembly != null)
+					resourceStream = resourceAssembly.GetManifestResourceStream(resourceName);
+			}
 
 			if (resourceStream == null)
 			{

--- a/lib/zmq.cs
+++ b/lib/zmq.cs
@@ -5,12 +5,18 @@
 
 	public static unsafe class zmq
 	{
-		private const string SodiumLibraryName = "libsodium";
-
+		// Under iOS, the libzmq and libsodium need to be linked statically into the project.
+		// The library name for the Dllimport then needs to be "__Internal".
+		// In addition, the libraries must not be loaded!
+		#if IOS_INTERNAL
+			private const string LibraryName = "__Internal";
+			private const string SodiumLibraryName = "__Internal";
+		#else
+			private const string LibraryName = "libzmq";
+			private const string SodiumLibraryName = "libsodium";
+		#endif
+		
 		private static readonly UnmanagedLibrary NativeLibSodium;
-
-		private const string LibraryName = "libzmq";
-
 		private static readonly UnmanagedLibrary NativeLib;
 
 		// From zmq.h (v3):
@@ -25,10 +31,12 @@
 
 		static zmq()
 		{
-			try { NativeLibSodium = Platform.LoadUnmanagedLibrary(SodiumLibraryName); } 
-			catch (System.IO.FileNotFoundException) { }
-
-			NativeLib = Platform.LoadUnmanagedLibrary(LibraryName);
+			#if !IOS_INTERNAL
+				try { NativeLibSodium = Platform.LoadUnmanagedLibrary(SodiumLibraryName); } 
+				catch (System.IO.FileNotFoundException) { }
+				
+				NativeLib = Platform.LoadUnmanagedLibrary(LibraryName);
+			#endif
 
 			int major, minor, patch;
 			version(out major, out minor, out patch);


### PR DESCRIPTION
## iPhone support

We use the clrzmq4 with Xamarin on iPhones. To achive this, we compiled libzmq and libsodium as static libraries and added them as native libraries to our Xamarin project. Then these modifications on clrzmq4 where needed to get it running:
- `GetHRForLastWin32Error` is not available in Xamarin and needs to be replaced with `Win32Exception` (should do the same)
- The name of the libraries needs to be `__Internal` because of the static libs
- Don't load the dynamic lib's in `LoadUnmanagedLibrary`
## Embedded libraries

In `ExtractManifestResource` when the libraries are not found, we check all loaded assemblies to find the embedded resource. This allows to embedd the libs into the assembly that used clrzmq4 which makes the deployment easy.
Just add the libraries to the project, set the build action to `Embedded resource` and set the correct resource identifier. This needs to be done manual in the *.csproj file because it's not supported by Visual Studio. There is an example how to do:

``` xml
  <ItemGroup>
    <EmbeddedResource Include="amd64\libsodium.dll">
      <LogicalName>ZeroMQ.libsodium.amd64.dll</LogicalName>
    </EmbeddedResource>
    <EmbeddedResource Include="amd64\libzmq.dll">
      <LogicalName>ZeroMQ.libzmq.amd64.dll</LogicalName>
    </EmbeddedResource>
    <EmbeddedResource Include="i386\libsodium.dll">
      <LogicalName>ZeroMQ.libsodium.i386.dll</LogicalName>
    </EmbeddedResource>
    <EmbeddedResource Include="i386\libzmq.dll">
      <LogicalName>ZeroMQ.libzmq.i386.dll</LogicalName>
    </EmbeddedResource>
  </ItemGroup>
```
