### PR TITLE
Prevent linker error in Xamarin

### DIFF
--- a/lib/Platform.Win32.cs
+++ b/lib/Platform.Win32.cs
@@ -119,7 +119,7 @@
 
 			public static Exception GetLastLibraryError()
 			{
-				return Marshal.GetExceptionForHR(Marshal.GetHRForLastWin32Error());
+				return new System.ComponentModel.Win32Exception();
 			}
 
 			[DllImport(KernelLib, CharSet = CharSet.Auto, BestFitMapping = false, SetLastError = true)]


### PR DESCRIPTION
Xamarin doesn't support `GetHRForLastWin32Error`. It creates a linker error when building for iOS.  According MSDN the Win32Exception without arguments will do the same and is not breaking the linker in Xamarin.
