### PR TITLE
detect iOS using loaded assemblies

### DIFF
--- a/lib/Platform.cs
+++ b/lib/Platform.cs
@@ -2,6 +2,7 @@ namespace ZeroMQ.lib
 {
 	using System;
 	using System.IO;
+	using System.Linq;
 	using System.Reflection;
 	using System.Runtime.InteropServices;
 
@@ -150,7 +151,7 @@ namespace ZeroMQ.lib
 				throw new PlatformNotSupportedException ();
 			} */
 
-			if (IsMonoTouch)
+			if (IsXamarinIOS || IsMonoTouch)
 			{
 				Kind = PlatformKind.__Internal;
 				// Name = PlatformName.__Internal;
@@ -166,7 +167,20 @@ namespace ZeroMQ.lib
 
 		public static bool IsMonoTouch
 		{
-			get { return Type.GetType("MonoTouch.ObjCRuntime.Class") != null; }
+			get
+			{
+				return AppDomain.CurrentDomain.GetAssemblies()
+					.Any(a => a.GetName().Name.Equals("monotouch", StringComparison.InvariantCultureIgnoreCase));
+			}
+		}
+		      
+		public static bool IsXamarinIOS
+		{
+			get
+			{
+				return AppDomain.CurrentDomain.GetAssemblies()
+					.Any(a => a.GetName().Name.Equals("Xamarin.iOS", StringComparison.InvariantCultureIgnoreCase));
+			}
 		}
 
 		public static void SetupImplementation(Type platformDependentType)


### PR DESCRIPTION
`Type.GetType()` is only working with full qualified type names including assembly etc. For types located in mscorlib the assembly name is not needed. See [MSDN](https://msdn.microsoft.com/en-us/library/w3f99sx1%28v=vs.110%29.aspx).

The code will no check for the existens of the monotouch or Xamarin.iOS assemblies. Monotouch is the legacy API. Xamarin.iOS is for the new unified API that has been released with Xamarin.iOS 8.6.
For more infos about the different API's see [Xamarin](https://developer.xamarin.com/guides/cross-platform/macios/unified/#Library_Split)
