### PR TITLE
Copy native libs using package build targets

### DIFF
--- a/ZeroMQ.nuspec
+++ b/ZeroMQ.nuspec
@@ -17,8 +17,9 @@
 	</metadata>
 	<files>
 		<!-- file src="**" target="content\" exclude="bin\**\*.*;obj\**\*.*;amd64\v*\*.*;i386\v*\*.*;*.user;ZeroMQ.*.zip" / -->
-		<file src="\bin\Release\i386\*.*" target="content\i386\" />
-		<file src="\bin\Release\amd64\*.*" target="content\amd64\" />
+		<file src="\ZeroMQ.targets" target="build\net40\ZeroMQ.targets" />
+		<file src="\bin\Release\i386\*.*" target="lib\net40\i386\" />
+		<file src="\bin\Release\amd64\*.*" target="lib\net40\amd64\" />
 		<file src="\bin\Release\**\*.*" target="lib\net40\" />
 	</files>
 </package>

--- a/ZeroMQ.targets
+++ b/ZeroMQ.targets
@@ -1,0 +1,8 @@
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<ItemGroup>
+		<None Include="$(MSBuildThisFileDirectory)..\..\lib\net40\**">
+			<Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
+</Project>


### PR DESCRIPTION
Using a simple MSBuild target, the native lib's can be copied to the output directory without adding them to each project as content.
