### PR TITLE
using ZeroMQ.targets to add the native binary files to user project.

### DIFF
--- a/ZeroMQ.nuspec
+++ b/ZeroMQ.nuspec
@@ -16,8 +16,14 @@
 		</references>
 	</metadata>
 	<files>
-		<file src="bin/Release/i386/*.*" target="content/i386/" />
-		<file src="bin/Release/amd64/*.*" target="content/amd64/" />
-		<file src="bin/Release/**/*.*" target="lib/net40/" />
+		<!-- targets file -->
+		<file src="ZeroMQ.targets" target="/build/net40/ZeroMQ.targets" />
+		
+		<!-- managed assembly -->
+		<file src="bin/Release/ZeroMQ.dll" target="lib/net40/" />
+		
+		<!-- native binary files -->
+		<file src="i386/**/*.*" target="/build/" />
+		<file src="amd64/**/*.*" target="/build/" />
 	</files>
 </package>

--- a/ZeroMQ.targets
+++ b/ZeroMQ.targets
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <ItemGroup>
+        <None Include="$(MSBuildThisFileDirectory)../amd64/libzmq.so">
+            <Link>amd64/libzmq.so</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Include="$(MSBuildThisFileDirectory)../amd64/libzmq.dll">
+            <Link>amd64/libzmq.dll</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Include="$(MSBuildThisFileDirectory)../amd64/libsodium.so">
+            <Link>amd64/libsodium.so</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Include="$(MSBuildThisFileDirectory)../amd64/libsodium.dll">
+            <Link>amd64/libsodium.dll</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Include="$(MSBuildThisFileDirectory)../i386/libzmq.so">
+            <Link>i386/libzmq.so</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Include="$(MSBuildThisFileDirectory)../i386/libzmq.dll">
+            <Link>i386/libzmq.dll</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Include="$(MSBuildThisFileDirectory)../i386/libsodium.so">
+            <Link>i386/libsodium.so</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Include="$(MSBuildThisFileDirectory)../i386/libsodium.dll">
+            <Link>i386/libsodium.dll</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
+</Project>


### PR DESCRIPTION
I tested the generated `ZeroMQ.4.1.0.18.nupkg` on local machine, here is the result:

the downloaded package folder:

```
D:\test\ConsoleApplication1\packages>tree /F ZeroMQ.4.1.0.18
卷 data 的文件夹 PATH 列表
卷序列号为 06E6-AAC7
D:\TEST\CONSOLEAPPLICATION1\PACKAGES\ZEROMQ.4.1.0.18
│  ZeroMQ.4.1.0.18.nupkg
│
├─build
│  ├─amd64
│  │      libsodium.dll
│  │      libsodium.so
│  │      libzmq.dll
│  │      libzmq.exp
│  │      libzmq.lib
│  │      libzmq.so
│  │
│  ├─i386
│  │      libsodium.dll
│  │      libsodium.so
│  │      libzmq.dll
│  │      libzmq.exp
│  │      libzmq.lib
│  │      libzmq.so
│  │
│  └─net40
│          ZeroMQ.targets
│
└─lib
    └─net40
            ZeroMQ.dll
```

The output bin folder:

```
D:\test\ConsoleApplication1\ConsoleApplication1>tree /f bin
卷 data 的文件夹 PATH 列表
卷序列号为 06E6-AAC7
D:\TEST\CONSOLEAPPLICATION1\CONSOLEAPPLICATION1\BIN
├─Debug
│  │  ConsoleApplication1.exe
│  │  ConsoleApplication1.exe.config
│  │  ConsoleApplication1.pdb
│  │  ZeroMQ.dll
│  │
│  ├─amd64
│  │      libsodium.dll
│  │      libsodium.so
│  │      libzmq.dll
│  │      libzmq.so
│  │
│  └─i386
│          libsodium.dll
│          libsodium.so
│          libzmq.dll
│          libzmq.so
│
└─Release
    │  ConsoleApplication1.exe
    │  ConsoleApplication1.exe.config
    │  ConsoleApplication1.pdb
    │  ZeroMQ.dll
    │
    ├─amd64
    │      libsodium.dll
    │      libsodium.so
    │      libzmq.dll
    │      libzmq.so
    │
    └─i386
            libsodium.dll
            libsodium.so
            libzmq.dll
            libzmq.so
```

The project structure in VS2015
![solution-explorer-screenshot](https://cloud.githubusercontent.com/assets/9129006/13144247/51a751f0-d684-11e5-9b49-822ffbf2b5fb.png)
