### PR TITLE
another way to read/write strings of ZFrame

### DIFF
--- a/StreamReaderNoClose.cs
+++ b/StreamReaderNoClose.cs
@@ -1,0 +1,87 @@
+using System.IO;
+using System.Text;
+
+namespace ZeroMQ
+{
+	internal class StreamReaderNoClose : StreamReader
+	{
+		public StreamReaderNoClose(Stream stream) : base(stream)
+		{
+		}
+
+		public StreamReaderNoClose(Stream stream, bool detectEncodingFromByteOrderMarks) : base(stream, detectEncodingFromByteOrderMarks)
+		{
+		}
+
+		public StreamReaderNoClose(Stream stream, Encoding encoding) : base(stream, encoding)
+		{
+		}
+
+		public StreamReaderNoClose(Stream stream, Encoding encoding, bool detectEncodingFromByteOrderMarks) : base(stream, encoding, detectEncodingFromByteOrderMarks)
+		{
+		}
+
+		public StreamReaderNoClose(Stream stream, Encoding encoding, bool detectEncodingFromByteOrderMarks, int bufferSize) : base(stream, encoding, detectEncodingFromByteOrderMarks, bufferSize)
+		{
+		}
+
+		public StreamReaderNoClose(string path) : base(path)
+		{
+		}
+
+		public StreamReaderNoClose(string path, bool detectEncodingFromByteOrderMarks) : base(path, detectEncodingFromByteOrderMarks)
+		{
+		}
+
+		public StreamReaderNoClose(string path, Encoding encoding) : base(path, encoding)
+		{
+		}
+
+		public StreamReaderNoClose(string path, Encoding encoding, bool detectEncodingFromByteOrderMarks) : base(path, encoding, detectEncodingFromByteOrderMarks)
+		{
+		}
+
+		public StreamReaderNoClose(string path, Encoding encoding, bool detectEncodingFromByteOrderMarks, int bufferSize) : base(path, encoding, detectEncodingFromByteOrderMarks, bufferSize)
+		{
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			// do nothing so the underlying stream will not be closed
+		}
+
+		/// <summary>
+		/// Description of StreamReader.ReadLine from MSDN:
+		/// A line is defined as a sequence of characters followed by a line feed ("\n"),
+		/// a carriage return ("\r"), or a carriage return immediately followed by a line
+		/// feed ("\r\n"). The string that is returned does not contain the terminating
+		/// carriage return or line feed. The returned value is null if the end of the
+		/// input stream is reached.
+		/// 
+		/// here we use Peek to check the EOF and return the line CONTAINING the terminating
+		/// \r, \n or \r\n to move the ZFrame position forward correctly
+		/// </summary>
+		public StringBuilder ReadLineWithTerminator()
+		{
+			if (Peek() == -1) return null;
+			StringBuilder sb = new StringBuilder();
+			while (true)
+			{
+				int c = Read();
+				if (c == -1) break;
+
+				sb.Append((char)c);
+				if (c == '\n')
+					break;
+				else if (c == '\r')
+				{
+					int c2 = Peek();
+					if (c2 == '\n')
+						sb.Append((char)Read());
+					break;
+				}
+			}
+			return sb;
+		}
+	}
+}

--- a/ZeroMQ.VS.csproj
+++ b/ZeroMQ.VS.csproj
@@ -48,6 +48,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="lib\Platform.__Internal.cs" />
+    <Compile Include="StreamReaderNoClose.cs" />
     <Compile Include="ZDevice.cs" />
     <Compile Include="Monitoring\ZMonitors.cs" />
     <Compile Include="Z85.cs" />


### PR DESCRIPTION
#56

It's really a tough PR :sob:
It's easy to write a string or write a line (`+"\r\n"`) to the ZFrame buffer which is actually a byte array. But is hard to read a string or read a line from the byte array because:
1. Different encoding has varying byte counts for characters. If one character has 3 bytes and the user calls ReadString(2, encoding), what shall the function do? Shall it raise an exception? Shall it move forward 2 bytes? Shall it check the encoding.DecoderFallback property?
2. The StreamReader which read characters from bytes has a buffer, so the underlying stream position will be moved forward more then bytes the actual string needed.

my PR made some workarounds in despite of performance hit:
1. When writing strings, convert to byte[] then call Write(byte[])
2. When reading strings, use a derived StreamReader to read decoded characters, deal with the terminating `'\r', '\n', '\r\n'`, and move ZFrame pointer forward manually

It's ugly, however to my limited test, it works.
Actually, I think it seems to be an over-design for ZFrame to provide the in-place string read/write functionality, because there are a lot of fussy encode/decode stuff and we usually do these operations in MemoryStream / StringBuilder / StreamReader / StreamWriter / Encoding and copy the underlying bytes from/to ZFrame. It's better to keep ZFrame a simple byte stream just like other streams and leave the string operations to user
