### PR TITLE
Support pyzmq under IronPython

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ obj/*
 amd64/v*
 i386/v*
 ZeroMQ.*.zip
+*.suo

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 ﻿
 **ZeroMQ C# namespace**
 
+This fork is for adding support needed so that clrzmq4 can be used as a backend by the pyzmq binding under IronPython.  Chat is set up under my matching fork of pyzmq:
+
+[![Join the chat at https://gitter.im/swn1/pyzmq](https://badges.gitter.im/swn1/pyzmq.svg)](https://gitter.im/swn1/pyzmq?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
 Hello. I've made a new ZeroMQ namespace for .NET Framework 4+ and mono 3+.
 
 ZeroMQ is built AnyCPU, to run on Windows (VC2010) and on GNU/Linux (C 4.8.4), i386 and amd64.

--- a/ZeroMQ.VS.csproj
+++ b/ZeroMQ.VS.csproj
@@ -44,6 +44,7 @@
     <AssemblyOriginatorKeyFile>ZeroMQ.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="IronPython, Version=2.7.5.0, Culture=neutral, PublicKeyToken=7f709c5b713576e1, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/ZeroMQ.VS.csproj
+++ b/ZeroMQ.VS.csproj
@@ -50,6 +50,9 @@
     <Reference Include="System.Configuration" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="backend\Context.cs" />
+    <Compile Include="backend\Frame.cs" />
+    <Compile Include="backend\Socket.cs" />
     <Compile Include="backend\zmq_poll.cs" />
     <Compile Include="lib\Platform.__Internal.cs" />
     <Compile Include="ZDevice.cs" />

--- a/ZeroMQ.VS.csproj
+++ b/ZeroMQ.VS.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ZeroMQ</RootNamespace>
     <AssemblyName>ZeroMQ</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\src\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -26,6 +26,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
@@ -34,6 +35,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
@@ -42,11 +44,13 @@
     <AssemblyOriginatorKeyFile>ZeroMQ.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Configuration" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="backend\zmq_poll.cs" />
     <Compile Include="lib\Platform.__Internal.cs" />
     <Compile Include="ZDevice.cs" />
     <Compile Include="Monitoring\ZMonitors.cs" />

--- a/ZeroMQ.VS.sln
+++ b/ZeroMQ.VS.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25123.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ZeroMQ.VS", "ZeroMQ.VS.csproj", "{6FFD872F-A4A4-4EFA-9B4D-4342BA6CF250}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6FFD872F-A4A4-4EFA-9B4D-4342BA6CF250}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6FFD872F-A4A4-4EFA-9B4D-4342BA6CF250}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6FFD872F-A4A4-4EFA-9B4D-4342BA6CF250}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6FFD872F-A4A4-4EFA-9B4D-4342BA6CF250}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/backend/Context.cs
+++ b/backend/Context.cs
@@ -26,7 +26,11 @@ namespace ZeroMQ
             public bool closed { get { return _ZContext == null || _ZContext.ContextPtr == IntPtr.Zero; } }
             public Socket socket(ZSocketType st)
             {
-                return new Socket(new ZSocket(_ZContext, st));
+                return new Socket(zsocket(st));
+            }
+            internal ZSocket zsocket(ZSocketType st)
+            {
+                return new ZSocket(_ZContext, st);
             }
         }
     }

--- a/backend/Context.cs
+++ b/backend/Context.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ZeroMQ
+{
+    public static partial class backend
+    {
+        public class Context
+        {
+            internal readonly ZContext _ZContext;
+            internal Context(ZContext zc)
+            {
+                if (zc == null)
+                    zc = ZContext.Create();
+                _ZContext = zc;
+            }
+            public Context(int io_threads = 1)
+            {
+                var zc = ZContext.Create();
+                zc.ThreadPoolSize = io_threads;
+                _ZContext = zc;
+            }
+            public bool closed { get { return _ZContext == null || _ZContext.ContextPtr == IntPtr.Zero; } }
+            public Socket socket(ZSocketType st)
+            {
+                return new Socket(new ZSocket(_ZContext, st));
+            }
+        }
+    }
+}

--- a/backend/Frame.cs
+++ b/backend/Frame.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ZeroMQ
+{
+    public static partial class backend
+    {
+        public class Frame
+        {
+            public readonly ZFrame _ZFrame;
+            internal Frame(ZFrame f)
+            {
+                _ZFrame = f;
+            }
+            public Frame(IEnumerable<Byte> data, bool track = false)
+            {
+                _ZFrame = new ZFrame(data.ToArray());
+                if (track)
+                    throw new NotImplementedException("Frame in clrzmq4.backend with track=true");
+            }
+
+            public Byte[] bytes
+            {
+                get
+                {
+                    return _ZFrame.Read();
+                }
+            }
+        }
+    }
+}

--- a/backend/Socket.cs
+++ b/backend/Socket.cs
@@ -15,14 +15,15 @@ namespace ZeroMQ
             {
                 _ZSocket = s;
             }
-            //public Socket(Context ctx, ZSocketType st)
-            //{
-            //    _ZSocket = ctx.socket(st);
-            //}
+            public Socket(Context ctx, ZSocketType st)
+            {
+                _ZSocket = ctx.zsocket(st);
+            }
             public Socket()
             {
                 throw new NotImplementedException("ZeroMQ.backend Socket default ctor should not be used");
                 // required to exist for python to subclass it.
+                // subclass instantiation seems to call default ctor first, then __init__?
             }
             public void set(ZSocketOption so, IEnumerable<Byte> buf)
             {
@@ -34,6 +35,44 @@ namespace ZeroMQ
             }
 
             public bool closed { get { return _ZSocket.SocketPtr == null; } }
+
+            public int linger
+            {
+                get { return _ZSocket.GetOptionInt32(ZSocketOption.LINGER); }
+                set { _ZSocket.SetOption(ZSocketOption.LINGER, value);  }
+            }
+
+            public IEnumerable<Byte> identity
+            {
+                get { return Encoding.UTF8.GetBytes(_ZSocket.IdentityString); }
+                set { _ZSocket.IdentityString = Encoding.UTF8.GetString(value.ToArray()); }
+            }
+
+            public void connect(string url)
+            {
+                _ZSocket.Connect(url);
+            }
+
+            public void send(ZFrame msg, int flags = 0, bool copy = false, bool track = false)
+            {
+                if (copy)
+                    msg = msg.Duplicate();
+                _ZSocket.SendFrame(msg, (ZSocketFlags)flags);
+                if (track)
+                    throw new NotImplementedException("tracking not yet wired up");
+            }
+
+            public void send(string msg, int flags = 0, bool copy = false, bool track = false)
+            {
+                send(Encoding.UTF8.GetBytes(msg), flags, copy, track);
+            }
+            public void send(IEnumerable<Byte> msg, int flags = 0, bool copy = false, bool track = false)
+            {
+                 var frm = new ZFrame(msg.ToArray());
+                _ZSocket.SendFrame(frm, (ZSocketFlags)flags);
+                if (track)
+                    throw new NotImplementedException("tracking not yet wired up");
+            }
         }
     }
 }

--- a/backend/Socket.cs
+++ b/backend/Socket.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ZeroMQ
+{
+    public static partial class backend
+    {
+        public class Socket
+        {
+            internal readonly ZSocket _ZSocket;
+            internal Socket(ZSocket s)
+            {
+                _ZSocket = s;
+            }
+            //public Socket(Context ctx, ZSocketType st)
+            //{
+            //    _ZSocket = ctx.socket(st);
+            //}
+            public Socket()
+            {
+                throw new NotImplementedException("ZeroMQ.backend Socket default ctor should not be used");
+                // required to exist for python to subclass it.
+            }
+            public void set(ZSocketOption so, IEnumerable<Byte> buf)
+            {
+                _ZSocket.SetOption(so, buf.ToArray());
+            }
+            public IEnumerable<Byte> get(ZSocketOption so)
+            {
+                return _ZSocket.GetOptionBytes(so);
+            }
+
+            public bool closed { get { return _ZSocket.SocketPtr == null; } }
+        }
+    }
+}

--- a/backend/zmq_poll.cs
+++ b/backend/zmq_poll.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ZeroMQ
+{
+    public static partial class backend
+    {
+        static ZPollItem make_pi(ZPoll f)
+        {
+            switch (f)
+            {
+                case ZPoll.In:
+                    return ZPollItem.CreateReceiver();
+                case ZPoll.Out:
+                    return ZPollItem.CreateSender();
+                case ZPoll.In | ZPoll.Out:
+                    return ZPollItem.CreateReceiverSender();
+            }
+            throw new System.ArgumentException("Poll flag must be valid ZPoll combination");
+        }
+        public static object zmq_poll(IEnumerable<dynamic> socks, int timeout)
+        {
+            var s2 = (from p in socks select ((ZSocket)p[0]._zmq_socket)).ToList();
+            var i2 = (from p in socks select make_pi((ZPoll)p[1])).ToList();
+            ZError err;
+            TimeSpan? ts = null;
+            if (timeout > 0)
+                ts = TimeSpan.FromMilliseconds(timeout);
+            ZPollItems.PollMany(s2, i2, ZPoll.In|ZPoll.Out, out err, ts);
+            return Enumerable.Zip(socks, i2, (p, i) => new object[] { p[0], (int)i.ReadyEvents }).ToList();
+        }
+    }
+}

--- a/backend/zmq_poll.cs
+++ b/backend/zmq_poll.cs
@@ -26,7 +26,7 @@ namespace ZeroMQ
             var i2 = (from p in socks select make_pi((ZPoll)p[1])).ToList();
             ZError err;
             TimeSpan? ts = null;
-            if (timeout > 0)
+            if (timeout >= 0)
                 ts = TimeSpan.FromMilliseconds(timeout);
             ZPollItems.PollMany(s2, i2, ZPoll.In|ZPoll.Out, out err, ts);
             return Enumerable.Zip(socks, i2, (p, i) => new object[] { p[0], (int)i.ReadyEvents }).Where(p => (int)p[1] != (int)ZPoll.None).ToList();

--- a/backend/zmq_poll.cs
+++ b/backend/zmq_poll.cs
@@ -22,14 +22,14 @@ namespace ZeroMQ
         }
         public static object zmq_poll(IEnumerable<dynamic> socks, int timeout)
         {
-            var s2 = (from p in socks select ((ZSocket)p[0]._zmq_socket)).ToList();
+            var s2 = (from p in socks select (ZSocket)p[0]._ZSocket).ToList();
             var i2 = (from p in socks select make_pi((ZPoll)p[1])).ToList();
             ZError err;
             TimeSpan? ts = null;
             if (timeout > 0)
                 ts = TimeSpan.FromMilliseconds(timeout);
             ZPollItems.PollMany(s2, i2, ZPoll.In|ZPoll.Out, out err, ts);
-            return Enumerable.Zip(socks, i2, (p, i) => new object[] { p[0], (int)i.ReadyEvents }).ToList();
+            return Enumerable.Zip(socks, i2, (p, i) => new object[] { p[0], (int)i.ReadyEvents }).Where(p => (int)p[1] != (int)ZPoll.None).ToList();
         }
     }
 }


### PR DESCRIPTION
I am submitting this PR for discussion, the work is not 100% complete.  Also, the README and project file changes should probably not be included.

Together with some other repos (see https://github.com/IronLanguages/main/issues/1290#issuecomment-219049315), these changes enable importing and using the jupyter_client library in IronPython 2.7.5.

Discussion topic is, do the maintainers of clrzmq4 want to take this code on?

Counterpoint: I think I can probably go back and make it all work without introducing changes into clrzmq4.  It's cleaner this way (less replication of logic in the python glue layer) but avoiding pushing requirements into yet another repo is valuable too.

See https://github.com/IronLanguages/main/issues/1289 for difficulty of working around this injection.

Opinions?
