### PR TITLE
XML documentation for NuGet package

### DIFF
--- a/ZeroMQ.VS.csproj
+++ b/ZeroMQ.VS.csproj
@@ -26,6 +26,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- XML documentation file for Debug configuration -->
+    <DocumentationFile>bin\Debug\ZeroMQ.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
@@ -34,6 +36,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- XML documentation file for Release configuration -->
+    <DocumentationFile>bin\Release\ZeroMQ.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>

--- a/ZeroMQ.mono.csproj
+++ b/ZeroMQ.mono.csproj
@@ -24,6 +24,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- XML documentation file for Debug configuration -->
+    <DocumentationFile>bin\Debug\ZeroMQ.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
@@ -32,6 +34,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- XML documentation file for Release configuration -->
+    <DocumentationFile>bin\Release\ZeroMQ.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>

--- a/ZeroMQ.nuspec
+++ b/ZeroMQ.nuspec
@@ -22,6 +22,9 @@
 		<!-- managed assembly -->
 		<file src="bin/Release/ZeroMQ.dll" target="lib/net40/" />
 		
+		<!-- XML documentation file -->
+		<file src="bin/Release/ZeroMQ.XML" target="lib/net40/" />
+		
 		<!-- native binary files -->
 		<file src="i386/libzmq.*" target="/build/i386/" />
 		<file src="i386/libsodium.*" target="/build/i386/" />


### PR DESCRIPTION
Hi,

It would be nice to have a documentation installed within the package from NuGet.
I've enabled XML documentation build option and added a reference in nuspec file.

_Of course it will need to rebuild, pack and publish a new NuGet package with bumped version._

**Before:**

![zmq-without-documentation](https://cloud.githubusercontent.com/assets/2134746/20052596/46916556-a507-11e6-9b54-d6247c57dbeb.png)

**After:**

![zmq-with-documentation](https://cloud.githubusercontent.com/assets/2134746/20052602/4e6ba07a-a507-11e6-9fde-c9199a625c82.png)