### PR TITLE
include current dll's location in search path

### DIFF
--- a/lib/Platform.Posix.cs
+++ b/lib/Platform.Posix.cs
@@ -35,6 +35,10 @@
 				"{Path}/{LibraryName}.a.*",
 				"{Path}/{LibraryName}.so",
 				"{Path}/{LibraryName}.so.*",
+				"{DllPath}/{LibraryName}.a",
+				"{DllPath}/{LibraryName}.a.*",
+				"{DllPath}/{LibraryName}.so",
+				"{DllPath}/{LibraryName}.so.*",
 			};
 
 			private const int RTLD_LAZY = 0x0001;
@@ -97,8 +101,10 @@
 
 				Platform.ExpandPaths(libraryPaths, "{Path}", EnumerateLibLdConf("/etc/ld.so.conf"));
 
-				Platform.ExpandPaths(libraryPaths, "{AppBase}", 
-					EnsureNotEndingSlash(
+				Platform.ExpandPaths(libraryPaths, "{DllPath}", EnsureNotEndingSlash(
+						Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)));
+
+				Platform.ExpandPaths(libraryPaths, "{AppBase}", EnsureNotEndingSlash(
 						AppDomain.CurrentDomain.BaseDirectory));
 
 				Platform.ExpandPaths(libraryPaths, "{LibraryName}", libraryName);

--- a/lib/Platform.Win32.cs
+++ b/lib/Platform.Win32.cs
@@ -23,6 +23,7 @@ namespace ZeroMQ.lib
 				@"{AppBase}\{Arch}\{Compiler}\{LibraryName}.dll",
 				// @"{AppBase}\{Arch}\{Compiler}\{LibraryName}-*.dll",
 				@"{AppBase}\{Arch}\{LibraryName}.dll",
+				@"{DllPath}\{Arch}\{LibraryName}.dll",
 				// @"{AppBase}\{Arch}\{LibraryName}-*.dll",
 				@"{System32}\{LibraryName}.dll",
 				// @"{System32}\{LibraryName}-*.dll",
@@ -57,6 +58,9 @@ namespace ZeroMQ.lib
 				var libraryPaths = new List<string>(Platform.LibraryPaths);
 
 				Platform.ExpandPaths(libraryPaths, "{System32}", Environment.SystemDirectory);
+	
+				Platform.ExpandPaths(libraryPaths, "{DllPath}", EnsureNotEndingBackSlash(
+						Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)));
 
 				Platform.ExpandPaths(libraryPaths, "{AppBase}", EnsureNotEndingBackSlash(
 						AppDomain.CurrentDomain.BaseDirectory));


### PR DESCRIPTION
This PR adds the base directory of `ZeroMQ.dll` to the search path for native libraries on Posix and Windows systems.