### PR TITLE
Problem: buffer allocated as dest for the call to zmq_z85_encode is one byte too small #89

### DIFF
--- a/Z85.cs
+++ b/Z85.cs
@@ -37,7 +37,8 @@ namespace ZeroMQ
 
 			var data = GCHandle.Alloc(decoded, GCHandleType.Pinned);
 
-			using (var dest = DispoIntPtr.Alloc(destLen))
+            // the buffer dest must be one byte larger than destLen to accomodate the null termination character
+			using (var dest = DispoIntPtr.Alloc(destLen + 1))
 			{
 				if (IntPtr.Zero == zmq.z85_encode(dest, data.AddrOfPinnedObject(), dataLen))
 				{


### PR DESCRIPTION
Solution: allocate an extra byte