### PR TITLE
Updating ZeroMQ.nuspec, v4.1.0.26

### DIFF
--- a/AssemblyInfo.cs
+++ b/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion("4.1.0.25")]
+[assembly: AssemblyVersion("4.1.0.26")]
 
 // The following attributes are used to specify the signing key for the assembly,
 // if desired. See the Mono documentation for more information about signing.

--- a/ZeroMQ.nuspec
+++ b/ZeroMQ.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
 	<metadata>
 		<id>ZeroMQ</id>
-		<version>4.1.0.25</version>
+		<version>4.1.0.26</version>
 
 		<authors>metadings, Pieter Hintjens, Martin Sustrik</authors>
 		<projectUrl>https://github.com/zeromq/clrzmq4/</projectUrl>


### PR DESCRIPTION
ZeroMQ/clrzmq4 v4.1.0.26 now has a Windows libzmq.dll, Linux libzmq.so and features a new MacOSX libzmq.dylib, thanks to @sigiesec !