### PR TITLE
137 Replace Mono's __Internal with libdl on Posix

### DIFF
--- a/lib/Platform.Posix.cs
+++ b/lib/Platform.Posix.cs
@@ -16,11 +16,7 @@
 		{
 			private const CallingConvention CCCdecl = CallingConvention.Cdecl;
 
-			private const string __Internal = "__Internal";
-
-			// private const string LibraryName = "libdl";
-
-			// public const string LibraryFileExtension = ".so";
+			private const string LibraryName = "libdl";
 
 			public static readonly string[] LibraryPaths = new string[] {
 				"{AppBase}/{Arch}/{Compiler}/{LibraryName}.so",
@@ -38,20 +34,17 @@
 			private const int RTLD_GLOBAL = 0x0100;
 			private const int RTLD_LOCAL = 0x0000;
 
-			[DllImport(__Internal, CallingConvention = CCCdecl)]
+			[DllImport(LibraryName, CallingConvention = CCCdecl)]
 			private static extern SafeLibraryHandle dlopen(IntPtr filename, int flags);
 
-			[DllImport(__Internal, CallingConvention = CCCdecl)]
+			[DllImport(LibraryName, CallingConvention = CCCdecl)]
 			private static extern int dlclose(IntPtr handle);
 
-			[DllImport(__Internal, CallingConvention = CCCdecl)]
+			[DllImport(LibraryName, CallingConvention = CCCdecl)]
 			private static extern IntPtr dlerror();
 
-			[DllImport(__Internal, CallingConvention = CCCdecl)]
+			[DllImport(LibraryName, CallingConvention = CCCdecl)]
 			private static extern IntPtr dlsym(SafeLibraryHandle handle, IntPtr symbol);
-			
-			[DllImport(__Internal)]
-			private static extern void mono_dllmap_insert(IntPtr assembly, IntPtr dll, IntPtr func, IntPtr tdll, IntPtr tfunc);
 
 			/* [DllImport("libc", EntryPoint = "chmod", SetLastError = true)]
 			internal static extern int syscall_chmod (IntPtr path, uint mode); */
@@ -64,15 +57,6 @@
 				}
 				Marshal.FreeHGlobal(pathPtr);
 			} */
-
-			private static void MonoDllMapInsert(string libraryName, string libraryPath)
-			{
-				IntPtr libraryNamePtr = Marshal.StringToHGlobalAnsi(libraryName);
-				IntPtr pathPtr = Marshal.StringToHGlobalAnsi(libraryPath);
-				mono_dllmap_insert(IntPtr.Zero, libraryNamePtr, IntPtr.Zero, pathPtr, IntPtr.Zero);
-				Marshal.FreeHGlobal(libraryNamePtr);
-				Marshal.FreeHGlobal(pathPtr);
-			}
 
 			public static UnmanagedLibrary LoadUnmanagedLibrary(string libraryName)
 			{
@@ -158,10 +142,6 @@
 
 						if (!handle.IsNullOrInvalid())
 						{
-							// This is Platform.Posix. In mono, just dlopen'ing the library doesn't work.
-							// Using DllImport("__Internal", EntryPoint = "mono_dllmap_insert") to get mono on the path.
-							MonoDllMapInsert(libraryName, file);
-
 							Trace.TraceInformation(string.Format("{0} Loaded binary \"{1}\"", 
 								traceLabel, file));
 
@@ -188,8 +168,6 @@
 
 					if (!handle.IsNullOrInvalid())
 					{
-						MonoDllMapInsert(libraryName, tempPath);
-
 						Trace.TraceInformation(string.Format("{0} Loaded binary from EmbeddedResource \"{1}\" from \"{2}\".", 
 							traceLabel, resourceName, tempPath));
 						


### PR DESCRIPTION
The libdl.so library supports the dlopen() API necessary for loading C/C++ libraries. This change is necessary to enable .Net Core support and resolves #137.