### PR TITLE
Problem: manual hack in README for libzmq.so

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,8 @@ The pre-built [nuget.org/packages/ZeroMQ/](https://www.nuget.org/packages/ZeroMQ
 
 You can place any native shared library or dynamic link libraries into a folder ~/Downloads/clrzmq4/amd64 or ~/Downloads/clrzmq4/i386, any libzmq.dll/.so/.dylib 3.x 4.x will work, important is just that the file name is `libzmq.dll`.
 
-Note: On ubuntu 18.04 / Linux Mint 19.1 I'm going to apt install `libzmq5` and create a link explicitly named `libzmq.so`:
 ```
-    sudo apt-get install libzmq5
-    sudo ln -s /usr/lib/x86_64-linux-gnu/libzmq.so.5  /usr/lib/x86_64-linux-gnu/libzmq.so
+    sudo apt-get install libzmq3-dev
 ```
 
 Get it


### PR DESCRIPTION
Solution: just install libzmq3-dev instead which already provides libzmq.so
as well as the library