### PR TITLE
Fix consuming native libraries in consumers projects

### DIFF
--- a/ZeroMQ.targets
+++ b/ZeroMQ.targets
@@ -4,41 +4,49 @@
 
 <!-- Windows -->
 
-    <Content Include="$(MSBuildThisFileDirectory)../amd64/libzmq.dll">
+    <None Include="$(MSBuildThisFileDirectory)../amd64/libzmq.dll">
         <Link>amd64/libzmq.dll</Link>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    </None>
 
-    <Content Include="$(MSBuildThisFileDirectory)../i386/libzmq.dll">
+    <None Include="$(MSBuildThisFileDirectory)../i386/libzmq.dll">
         <Link>i386/libzmq.dll</Link>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    </None>
 
 
 <!-- Linux -->
 
-    <Content Include="$(MSBuildThisFileDirectory)../amd64/libzmq.so">
+    <None Include="$(MSBuildThisFileDirectory)../amd64/libzmq.so">
         <Link>amd64/libzmq.so</Link>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    </None>
 
-    <!-- Content Include="$(MSBuildThisFileDirectory)../i386/libzmq.so">
+    <!-- None Include="$(MSBuildThisFileDirectory)../i386/libzmq.so">
         <Link>i386/libzmq.so</Link>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content -->
+    </None -->
 
 
 <!-- MacOS -->
 
-    <Content Include="$(MSBuildThisFileDirectory)../amd64/libzmq.dylib">
+    <None Include="$(MSBuildThisFileDirectory)../amd64/libzmq.dylib">
         <Link>amd64/libzmq.dylib</Link>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    </None>
 
-    <!-- Content Include="$(MSBuildThisFileDirectory)../i386/libzmq.dylib">
+    <!-- None Include="$(MSBuildThisFileDirectory)../i386/libzmq.dylib">
         <Link>i386/libzmq.dylib</Link>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content -->
+    </None -->
 
 </ItemGroup>
+ <Target Name="FixZeroMqPackageConsumptions" BeforeTargets="CollectPackageReferences">
+    <ItemGroup>
+      <!--Force consuming this targets file in all projects that have indirect reference to this package-->
+      <PackageReference Update="@(PackageReference)" Condition="'%(Identity)' == '$(MSBuildThisFileName)'">
+        <PrivateAssets>Analyzers</PrivateAssets>
+      </PackageReference>
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
Problem: If the consuming project is also packed as nuget then the native libraries are incorrectly handled - there are copied to `content` and `contentFiles` folders therefor incorrectly consumed by the downstream projects.

Solution:
1) Changing `Content` to `None` item group where the native libraries are attached prevents adding them to the nuget package of the consuming project (`None` item group is not packed by default)
2) Adding `FixZeroMqPackageConsumptions` target prevents excluding `ZeroMQ.targets` from consumption in the projects that indirectly reference `ZeroMQ` nuget package. This will generate the following dependency in the nuspect:

```xml
<dependency id="ZeroMQ" version="4.1.0.31" include="Runtime,Compile,Build,Native,ContentFiles,BuildTransitive" />
```
instead of

```xml
<dependency id="ZeroMQ" version="4.1.0.31" exclude="Build,Analyzers" />
```