### PR TITLE
#178: Remove readonly modifier from ZError 

### DIFF
--- a/ZError.cs
+++ b/ZError.cs
@@ -169,7 +169,7 @@ namespace ZeroMQ
 			}
 		}
 
-		public static readonly ZError
+		public static ZError
 			// DEFAULT = new ZmqError(0),
 			EPERM,
 			ENOENT,


### PR DESCRIPTION
In .NET Core 3.0 readonly fields cannot be initialized via reflection outside the static constructor. This should fix #178. A similar issue is discussed here https://github.com/dotnet/coreclr/issues/21268