### PR TITLE
Remove trailing zeros from Socket options strings

### DIFF
--- a/ZSocket.cs
+++ b/ZSocket.cs
@@ -920,7 +920,9 @@ namespace ZeroMQ
 			{
 				if (GetOption(option, optionValue, ref optionLength))
 				{
-					value = Marshal.PtrToStringAnsi(optionValue, optionLength);
+                    if (optionLength > 0 && Marshal.ReadByte(optionValue.Ptr, optionLength - 1) == 0)
+                        optionLength--; // remove traling '\0'
+					value = Marshal.PtrToStringAnsi(optionValue, optionLength); 
 					return true;
 				}
 				return false;


### PR DESCRIPTION
E.g. the LastEndpoint property of a ZSocket contains a '\0'

(Sorry my tabs setting is visual studio seems to be wrong).