### PR TITLE
added blacklist precedence (blacklist trumps whitelist)

### DIFF
--- a/ZAuth.cs
+++ b/ZAuth.cs
@@ -284,21 +284,6 @@ namespace ZeroMQ
             //  Is address explicitly whitelisted or blacklisted?
             bool allowed = false;
             bool denied = false;
-            if (whitelist.Count > 0)
-            {
-                if (whitelist.Contains(request.Address))
-                {
-                    allowed = true;
-                    if (verbose)
-                        Info("zauth: - passed (whitelist) address=" + request.Address);
-                }
-                else
-                {
-                    denied = true;
-                    if (verbose)
-                        Info("zauth: - denied (whitelist) address=" + request.Address);
-                }
-            }
 
             if (blacklist.Count > 0)
             {
@@ -313,6 +298,22 @@ namespace ZeroMQ
                     allowed = true;
                     if (verbose)
                         Info("zauth: -  passed (not in blacklist) address=" + request.Address);
+                }
+            }
+
+            if (!denied && whitelist.Count > 0)
+            {
+                if (whitelist.Contains(request.Address))
+                {
+                    allowed = true;
+                    if (verbose)
+                        Info("zauth: - passed (whitelist) address=" + request.Address);
+                }
+                else
+                {
+                    denied = true;
+                    if (verbose)
+                        Info("zauth: - denied (whitelist) address=" + request.Address);
                 }
             }
 


### PR DESCRIPTION
_<this proposed change makes more sense in `split` view>_
I read a warning in the docs that one could not use both blacklist and whitelist at the same time, ...  This is because the blacklist processing overrides the previous whitelist processing.  Assuming that blacklist processing should have precedence, that if the address is in both blacklist and whitelist, then the blacklist, as more restrictive, should win.

This proposed change performs the blacklist check first.  Then, only if the address is not explicitly denied from the blacklist will the whitelist processing be performed.

There will be no impact to those implementations that have at most one {black|white}list.

I'm sure this pull-request isn't a big deal, as without wildcards most developers would not use both, ... but at least consider processing blacklist first, otherwise the blacklist processing completely undoes a whitelist denial.